### PR TITLE
Fixed argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ rkdeveloptool db loader.flash.bin
 
 ```
 # This loader.bin is always based at 0xFF001000.
-$ ./rk-packsign --usb --471 loader.bin -o loader.usb.bin
+$ ./rk-packsign --rkldr --471 loader.bin -o loader.usb.bin
 $ rkdeveloptool db loader.usb.bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ rkdeveloptool db loader.usb.bin
 - To add signing to any of the above steps, add --key to the command line. For example:
 
 ```
-$ ./rk-packsign --key private_key.pem --usb --471 loader.bin -o loader.usb.bin
+$ ./rk-packsign --key private_key.pem --rkldr --471 loader.bin -o loader.usb.bin
 ```
 
 # Generating the OTP data for Secure Boot enablement


### PR DESCRIPTION
Argument name has been changed at https://github.com/DualTachyon/rk3588-tools/commit/1f0e1e10fba5736d7ca7e7ea96a3ecff575028b1#diff-b827a78c2a5c9ba37afccc7d0ffded61644d2035b1a3eeabbfac140121f7e441R55
I change this in README